### PR TITLE
Make method signatures match parent class

### DIFF
--- a/src/Records/Field.php
+++ b/src/Records/Field.php
@@ -120,7 +120,7 @@ class Field extends HypermediaEnabledData
      *
      * @param array $o
      */
-    public function initFromArray($o)
+    public function initFromArray(array $o)
     {
         if (isset($o['type'])) {
             $this->type = $o["type"];
@@ -148,7 +148,7 @@ class Field extends HypermediaEnabledData
      *
      * @return bool Whether a child element was set.
      */
-    protected function setKnownChildElement($xml)
+    protected function setKnownChildElement(\XMLReader $xml)
     {
         $happened = parent::setKnownChildElement($xml);
         if ($happened) {
@@ -174,7 +174,7 @@ class Field extends HypermediaEnabledData
      *
      * @return bool Whether an attribute was set.
      */
-    protected function setKnownAttribute($xml)
+    protected function setKnownAttribute(\XMLReader $xml)
     {
         if (parent::setKnownAttribute($xml)) {
             return true;
@@ -194,7 +194,7 @@ class Field extends HypermediaEnabledData
      *
      * @param \XMLWriter $writer The XML writer.
      */
-    public function writeXmlContents($writer)
+    public function writeXmlContents(\XMLWriter $writer)
     {
         if ($this->type) {
             $writer->writeAttribute('type', $this->type);


### PR DESCRIPTION
Otherwise, PHP Strict notices are thrown
